### PR TITLE
Iter23

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ vendor/
 golangci-lint/
 
 *backup.txt
+*.pem

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint deps
+.PHONY: help lint deps keys
 
 # ===========================
 # HELP: Список доступных команд
@@ -27,3 +27,9 @@ deps:  ## Очищает и обновляет зависимости проек
 	rm -f go.sum
 	go mod tidy -v
 	go mod verify
+
+# ===========================
+# KEYS: Генерация ключей
+# ===========================
+keys:  ## Генерирует приватный и публичный ключи
+	go run ./cmd/keycli/main.go -private private.pem -public public.pem -size 4096

--- a/cmd/agent/init.go
+++ b/cmd/agent/init.go
@@ -68,6 +68,15 @@ func loadConfig() (*config.Config, error) {
 // initAgent initializes the agent, including the
 // metrics collectors, metrics senders.
 func initAgent(cfg *config.Config, logger *zap.SugaredLogger) *agent.Agent {
+	var crptKey string
+	if cfg.CryptoKey != "" {
+		keyData, err := os.ReadFile(cfg.CryptoKey)
+		if err != nil {
+			logger.Fatalf("failed to read crypto key from file: %v", err)
+		}
+		crptKey = string(keyData)
+	}
+
 	return agent.NewAgent(
 		convert.IntegerToSeconds(cfg.PollInterval),
 		convert.IntegerToSeconds(cfg.ReportInterval),
@@ -75,6 +84,7 @@ func initAgent(cfg *config.Config, logger *zap.SugaredLogger) *agent.Agent {
 		cfg.RateLimit,
 		cfg.ServerAddress,
 		cfg.SigningKey,
+		crptKey,
 	)
 }
 

--- a/cmd/agent/init.go
+++ b/cmd/agent/init.go
@@ -43,7 +43,13 @@ func printAppInfo() {
 
 // mainContext initializes the main application context with a cancel function.
 func mainContext() (context.Context, context.CancelFunc) {
-	return signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	return signal.NotifyContext(
+		context.Background(),
+		os.Interrupt,
+		syscall.SIGTERM,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+	)
 }
 
 // baseLogger initializes and returns a SugaredLogger instance

--- a/cmd/keycli/main.go
+++ b/cmd/keycli/main.go
@@ -69,7 +69,7 @@ func savePrivateKey(key *rsa.PrivateKey, filepath string) error {
 
 	// Write the PEM block to the file
 	if err = pem.Encode(f, pemBlock); err != nil {
-		return fmt.Errorf("failed to encode private key to PEM format")
+		return fmt.Errorf("failed to encode private key to PEM format: %w", err)
 	}
 	return nil
 }

--- a/cmd/keycli/main.go
+++ b/cmd/keycli/main.go
@@ -1,0 +1,95 @@
+// Package main provides a CLI tool for generating RSA key pairs and saving them to files.
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"flag"
+	"fmt"
+	"os"
+)
+
+func main() {
+	// Command-line flags
+	var (
+		privateKeyPath string
+		publicKeyPath  string
+		keySize        int
+	)
+
+	flag.StringVar(&privateKeyPath, "private", "private_key.pem", "Path to save the private key")
+	flag.StringVar(&publicKeyPath, "public", "public_key.pem", "Path to save the public key")
+	flag.IntVar(&keySize, "size", 2048, "Key size in bits (2048 or 4096 is recommended)")
+	flag.Parse()
+
+	fmt.Println("Generating RSA key pair...")
+
+	// Generate the RSA private key
+	privateKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		panic(fmt.Errorf("failed to generate private key: %w", err))
+	}
+
+	// Save the private key to a file
+	if err := savePrivateKey(privateKey, privateKeyPath); err != nil {
+		panic(err)
+	}
+
+	// Save the public key to a file
+	if err := savePublicKey(&privateKey.PublicKey, publicKeyPath); err != nil {
+		panic(err)
+	}
+
+	fmt.Println("Keys successfully generated!")
+	fmt.Println("Private key saved to:", privateKeyPath)
+	fmt.Println("Public key saved to:", publicKeyPath)
+}
+
+// savePrivateKey saves the RSA private key to the specified file in PEM format.
+// The file will be created or overwritten if it already exists.
+func savePrivateKey(key *rsa.PrivateKey, filepath string) error {
+	f, err := os.Create(filepath)
+	if err != nil {
+		return fmt.Errorf("failed to create private key file: %w", err)
+	}
+	defer f.Close()
+
+	// Marshal the private key to PKCS#1 ASN.1 DER format
+	privateKeyBytes := x509.MarshalPKCS1PrivateKey(key)
+
+	// Create a PEM block for the private key
+	pemBlock := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: privateKeyBytes,
+	}
+
+	// Write the PEM block to the file
+	return pem.Encode(f, pemBlock)
+}
+
+// savePublicKey saves the RSA public key to the specified file in PEM format.
+// The file will be created or overwritten if it already exists.
+func savePublicKey(key *rsa.PublicKey, filepath string) error {
+	f, err := os.Create(filepath)
+	if err != nil {
+		return fmt.Errorf("failed to create public key file: %w", err)
+	}
+	defer f.Close()
+
+	// Marshal the public key to PKIX ASN.1 DER format
+	publicKeyBytes, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		return fmt.Errorf("failed to serialize public key: %w", err)
+	}
+
+	// Create a PEM block for the public key
+	pemBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: publicKeyBytes,
+	}
+
+	// Write the PEM block to the file
+	return pem.Encode(f, pemBlock)
+}

--- a/cmd/keycli/readme.md
+++ b/cmd/keycli/readme.md
@@ -1,0 +1,52 @@
+# KeyCLI - RSA Key Pair Generator
+
+## Features
+
+- Generate RSA private and public key pairs.
+- Specify the key size (2048 or 4096 bits recommended).
+- Save the keys to custom file paths.
+
+## Usage
+
+Run the utility with the following flags:
+
+- `-private`: Path to save the private key (default: `private_key.pem`).
+- `-public`: Path to save the public key (default: `public_key.pem`).
+- `-size`: Key size in bits (default: `2048`).
+
+### Example Commands
+
+1. Generate a key pair with default settings:
+	```bash
+	./keycli
+	```
+
+2. Generate a key pair with a custom private key path:
+	```bash
+	./keycli -private my_private_key.pem
+	```
+
+3. Generate a key pair with a custom public key path:
+	```bash
+	./keycli -public my_public_key.pem
+	```
+
+4. Generate a key pair with a custom key size (e.g., 4096 bits):
+	```bash
+	./keycli -size 4096
+	```
+
+5. Generate a key pair with all custom settings:
+	```bash
+	./keycli -private my_private_key.pem -public my_public_key.pem -size 4096
+	```
+
+## Output
+
+- The private key will be saved to the file specified by the `-private` flag.
+- The public key will be saved to the file specified by the `-public` flag.
+
+## Notes
+
+- Ensure you have write permissions to the specified file paths.
+- Use a key size of at least 2048 bits for secure encryption.

--- a/cmd/server/init.go
+++ b/cmd/server/init.go
@@ -190,7 +190,7 @@ func setupGracefulShutdown(
 	shutdownActions ...func(),
 ) {
 	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM, syscall.SIGINT, syscall.SIGTERM)
 
 	go func() {
 		<-signalChan

--- a/cmd/server/init.go
+++ b/cmd/server/init.go
@@ -108,9 +108,19 @@ func initComponentsWithShutdownActs(
 	}
 	shutdownActions = append(shutdownActions, repoWithShutdownFunc.shutdown)
 
+	var crptKey string
+	if cfg.CryptoKey != "" {
+		keyData, err := os.ReadFile(cfg.CryptoKey)
+		if err != nil {
+			logger.Fatalf("failed to read crypto key from file: %v", err)
+		}
+		crptKey = string(keyData)
+	}
+
 	echoDelivery := delivery.NewEchoServer(
 		cfg.ServerAddress,
 		cfg.SigningKey,
+		crptKey,
 		repoWithShutdownFunc.repository,
 		logger.Named(loggerNameDelivery),
 	)

--- a/internal/agent/agent/agent.go
+++ b/internal/agent/agent/agent.go
@@ -58,6 +58,7 @@ type Agent struct {
 	sendQueue      chan *entity.Metrics
 	serverAddress  string
 	signKey        string
+	cryptoKey      string
 	pollInterval   time.Duration
 	reportInterval time.Duration
 	maxSendRate    int
@@ -82,6 +83,7 @@ func NewAgent(
 	maxSendRate int,
 	serverAddress string,
 	signKey string,
+	cryptoKey string,
 ) *Agent {
 	logger.Infof(
 		"Initializing Agent: pollInterval=%ds, reportInterval=%ds",
@@ -96,6 +98,7 @@ func NewAgent(
 		maxSendRate:    maxSendRate,
 		serverAddress:  serverAddress,
 		signKey:        signKey,
+		cryptoKey:      cryptoKey,
 	}
 }
 
@@ -138,6 +141,7 @@ func (a *Agent) Start(ctx context.Context) {
 		a.maxSendRate,
 		a.serverAddress,
 		a.signKey,
+		a.cryptoKey,
 		streamSenderLogger,
 	)
 

--- a/internal/agent/agent/agent_test.go
+++ b/internal/agent/agent/agent_test.go
@@ -43,6 +43,7 @@ func TestAgent_Start(t *testing.T) {
 				tc.maxSendRate,
 				"http://localhost:8080",
 				"dummyKey",
+				"",
 			)
 
 			// Start a goroutine to continuously drain the sendQueue.

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -19,6 +19,7 @@ const (
 	defaultSigningKey     = ""
 	defaultRateLimit      = 3
 	defaultPprofFlag      = false
+	defaultCryptoKey      = ""
 )
 
 // Config holds the configuration settings for the application.
@@ -31,6 +32,7 @@ type Config struct {
 	ReportInterval int    `env:"REPORT_INTERVAL"` // Interval for reporting metrics.
 	RateLimit      int    `env:"RATE_LIMIT"`      // Maximum rate for sending HTTP requests per interval.
 	PprofFlag      bool   `env:"PPROF_FLAG"`      // Flag to enable or disable profiling with pprof.
+	CryptoKey      string `env:"CRYPTO_KEY"`      // Path to public key file.
 }
 
 // ParseConfig initializes a new Config instance with default values, then overrides these values
@@ -50,6 +52,7 @@ func ParseConfig() (*Config, error) {
 		SigningKey:     defaultSigningKey,
 		RateLimit:      defaultRateLimit,
 		PprofFlag:      defaultPprofFlag,
+		CryptoKey:      defaultCryptoKey,
 	}
 
 	// Parse command-line arguments or set default settings if no arguments are provided.
@@ -76,5 +79,6 @@ func parseFlagsOrSetDefault(cfg *Config) {
 	flag.StringVar(&cfg.SigningKey, "k", cfg.SigningKey, "Signing key used for creating request signatures.")
 	flag.IntVar(&cfg.RateLimit, "l", cfg.RateLimit, "Maximum rate for sending HTTP requests per interval.")
 	flag.BoolVar(&cfg.PprofFlag, "pf", cfg.PprofFlag, "Enable or disable profiling with pprof.")
+	flag.StringVar(&cfg.CryptoKey, "crypto-key", cfg.CryptoKey, "Path to public key file.")
 	flag.Parse()
 }

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -26,13 +26,13 @@ const (
 // It contains the server address, signing key, intervals for polling and reporting metrics,
 // a rate limit for HTTP requests, and a flag for enabling or disabling pprof profiling.
 type Config struct {
-	ServerAddress  string `env:"ADDRESS"`         // Address of the server to connect to.
-	SigningKey     string `env:"KEY"`             // Key used for signing requests to the server.
-	PollInterval   int    `env:"POLL_INTERVAL"`   // Interval for polling metrics.
-	ReportInterval int    `env:"REPORT_INTERVAL"` // Interval for reporting metrics.
-	RateLimit      int    `env:"RATE_LIMIT"`      // Maximum rate for sending HTTP requests per interval.
-	PprofFlag      bool   `env:"PPROF_FLAG"`      // Flag to enable or disable profiling with pprof.
-	CryptoKey      string `env:"CRYPTO_KEY"`      // Path to public key file.
+	ServerAddress  string `env:"ADDRESS"`
+	SigningKey     string `env:"KEY"`
+	CryptoKey      string `env:"CRYPTO_KEY"`
+	PollInterval   int    `env:"POLL_INTERVAL"`
+	ReportInterval int    `env:"REPORT_INTERVAL"`
+	RateLimit      int    `env:"RATE_LIMIT"`
+	PprofFlag      bool   `env:"PPROF_FLAG"`
 }
 
 // ParseConfig initializes a new Config instance with default values, then overrides these values

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -5,10 +5,8 @@
 package config
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/caarlos0/env/v6"
 )
@@ -28,13 +26,13 @@ const (
 // It contains the server address, signing key, intervals for polling and reporting metrics,
 // a rate limit for HTTP requests, and a flag for enabling or disabling pprof profiling.
 type Config struct {
-	ServerAddress  string `env:"ADDRESS"         json:"server_address"`
-	SigningKey     string `env:"KEY"             json:"signing_key"`
-	CryptoKey      string `env:"CRYPTO_KEY"      json:"crypto_key"`
-	PollInterval   int    `env:"POLL_INTERVAL"   json:"poll_interval"`
-	ReportInterval int    `env:"REPORT_INTERVAL" json:"report_interval"`
-	RateLimit      int    `env:"RATE_LIMIT"      json:"rate_limit"`
-	PprofFlag      bool   `env:"PPROF_FLAG"      json:"pprof_flag"`
+	ServerAddress  string `env:"ADDRESS"`
+	SigningKey     string `env:"KEY"`
+	CryptoKey      string `env:"CRYPTO_KEY"`
+	PollInterval   int    `env:"POLL_INTERVAL"`
+	ReportInterval int    `env:"REPORT_INTERVAL"`
+	RateLimit      int    `env:"RATE_LIMIT"`
+	PprofFlag      bool   `env:"PPROF_FLAG"`
 }
 
 // ParseConfig initializes a new Config instance with default values, then overrides these values
@@ -45,20 +43,6 @@ type Config struct {
 // Returns:
 //   - *Config: A pointer to the populated Config structure.
 //   - error: An error if environment variable parsing fails; otherwise, nil.
-//
-// ParseConfig initializes and returns a Config object by parsing configuration
-// from multiple sources in the following order of precedence:
-// 1. Default settings are applied.
-// 2. Configuration file values are parsed and override defaults.
-// 3. Command-line arguments are parsed and override previous values.
-// 4. Environment variables are parsed and override previous values.
-//
-// If any error occurs during the parsing of the configuration file or
-// environment variables, it returns an error.
-//
-// Returns:
-// - A pointer to the populated Config object.
-// - An error if parsing fails at any stage.
 func ParseConfig() (*Config, error) {
 	// Default settings for the service configuration.
 	cfg := Config{
@@ -71,10 +55,6 @@ func ParseConfig() (*Config, error) {
 		CryptoKey:      defaultCryptoKey,
 	}
 
-	if err := parseConfigFile(&cfg); err != nil {
-		return nil, fmt.Errorf("error parsing config file: %w", err)
-	}
-
 	// Parse command-line arguments or set default settings if no arguments are provided.
 	parseFlagsOrSetDefault(&cfg)
 
@@ -84,45 +64,6 @@ func ParseConfig() (*Config, error) {
 	}
 
 	return &cfg, nil
-}
-
-// parseConfigFile parses the configuration for the application.
-// It first attempts to read the configuration file path from the command-line
-// flag "-c". If the flag is not provided, it falls back to the "CONFIG"
-// environment variable. If a configuration file path is found, it reads the
-// file and unmarshals its JSON content into the provided Config struct.
-//
-// Parameters:
-//   - cfg: A pointer to a Config struct where the parsed configuration will be stored.
-//
-// Returns:
-//   - An error if there is an issue with parsing command-line flags, reading the
-//     configuration file, or unmarshaling the JSON content. Returns nil if the
-//     configuration is successfully parsed.
-func parseConfigFile(cfg *Config) error {
-	var configPath string
-
-	fs := flag.NewFlagSet("config", flag.ContinueOnError)
-	fs.StringVar(&configPath, "c", "", "Path to JSON config file")
-	if err := fs.Parse(os.Args[1:]); err != nil {
-		return fmt.Errorf("error parsing command-line flags: %w", err)
-	}
-
-	if configPath == "" {
-		configPath = os.Getenv("CONFIG")
-	}
-
-	if configPath != "" {
-		data, err := os.ReadFile(configPath)
-		if err != nil {
-			return fmt.Errorf("failed to read config file: %w", err)
-		}
-
-		if err := json.Unmarshal(data, cfg); err != nil {
-			return fmt.Errorf("cannot parse JSON config %q: %w", configPath, err)
-		}
-	}
-	return nil
 }
 
 // parseFlagsOrSetDefault populates the Config structure with values provided as command-line flags.

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -5,8 +5,10 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/caarlos0/env/v6"
 )
@@ -26,13 +28,13 @@ const (
 // It contains the server address, signing key, intervals for polling and reporting metrics,
 // a rate limit for HTTP requests, and a flag for enabling or disabling pprof profiling.
 type Config struct {
-	ServerAddress  string `env:"ADDRESS"`
-	SigningKey     string `env:"KEY"`
-	CryptoKey      string `env:"CRYPTO_KEY"`
-	PollInterval   int    `env:"POLL_INTERVAL"`
-	ReportInterval int    `env:"REPORT_INTERVAL"`
-	RateLimit      int    `env:"RATE_LIMIT"`
-	PprofFlag      bool   `env:"PPROF_FLAG"`
+	ServerAddress  string `env:"ADDRESS"         json:"server_address"`
+	SigningKey     string `env:"KEY"             json:"signing_key"`
+	CryptoKey      string `env:"CRYPTO_KEY"      json:"crypto_key"`
+	PollInterval   int    `env:"POLL_INTERVAL"   json:"poll_interval"`
+	ReportInterval int    `env:"REPORT_INTERVAL" json:"report_interval"`
+	RateLimit      int    `env:"RATE_LIMIT"      json:"rate_limit"`
+	PprofFlag      bool   `env:"PPROF_FLAG"      json:"pprof_flag"`
 }
 
 // ParseConfig initializes a new Config instance with default values, then overrides these values
@@ -43,6 +45,20 @@ type Config struct {
 // Returns:
 //   - *Config: A pointer to the populated Config structure.
 //   - error: An error if environment variable parsing fails; otherwise, nil.
+//
+// ParseConfig initializes and returns a Config object by parsing configuration
+// from multiple sources in the following order of precedence:
+// 1. Default settings are applied.
+// 2. Configuration file values are parsed and override defaults.
+// 3. Command-line arguments are parsed and override previous values.
+// 4. Environment variables are parsed and override previous values.
+//
+// If any error occurs during the parsing of the configuration file or
+// environment variables, it returns an error.
+//
+// Returns:
+// - A pointer to the populated Config object.
+// - An error if parsing fails at any stage.
 func ParseConfig() (*Config, error) {
 	// Default settings for the service configuration.
 	cfg := Config{
@@ -55,6 +71,10 @@ func ParseConfig() (*Config, error) {
 		CryptoKey:      defaultCryptoKey,
 	}
 
+	if err := parseConfigFile(&cfg); err != nil {
+		return nil, fmt.Errorf("error parsing config file: %w", err)
+	}
+
 	// Parse command-line arguments or set default settings if no arguments are provided.
 	parseFlagsOrSetDefault(&cfg)
 
@@ -64,6 +84,45 @@ func ParseConfig() (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// parseConfigFile parses the configuration for the application.
+// It first attempts to read the configuration file path from the command-line
+// flag "-c". If the flag is not provided, it falls back to the "CONFIG"
+// environment variable. If a configuration file path is found, it reads the
+// file and unmarshals its JSON content into the provided Config struct.
+//
+// Parameters:
+//   - cfg: A pointer to a Config struct where the parsed configuration will be stored.
+//
+// Returns:
+//   - An error if there is an issue with parsing command-line flags, reading the
+//     configuration file, or unmarshaling the JSON content. Returns nil if the
+//     configuration is successfully parsed.
+func parseConfigFile(cfg *Config) error {
+	var configPath string
+
+	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	fs.StringVar(&configPath, "c", "", "Path to JSON config file")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return fmt.Errorf("error parsing command-line flags: %w", err)
+	}
+
+	if configPath == "" {
+		configPath = os.Getenv("CONFIG")
+	}
+
+	if configPath != "" {
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			return fmt.Errorf("failed to read config file: %w", err)
+		}
+
+		if err := json.Unmarshal(data, cfg); err != nil {
+			return fmt.Errorf("cannot parse JSON config %q: %w", configPath, err)
+		}
+	}
+	return nil
 }
 
 // parseFlagsOrSetDefault populates the Config structure with values provided as command-line flags.

--- a/internal/agent/config/config.go
+++ b/internal/agent/config/config.go
@@ -5,8 +5,10 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/caarlos0/env/v6"
 )
@@ -20,19 +22,21 @@ const (
 	defaultRateLimit      = 3
 	defaultPprofFlag      = false
 	defaultCryptoKey      = ""
+	defaultConfigPath     = ""
 )
 
 // Config holds the configuration settings for the application.
 // It contains the server address, signing key, intervals for polling and reporting metrics,
 // a rate limit for HTTP requests, and a flag for enabling or disabling pprof profiling.
 type Config struct {
-	ServerAddress  string `env:"ADDRESS"`
-	SigningKey     string `env:"KEY"`
-	CryptoKey      string `env:"CRYPTO_KEY"`
-	PollInterval   int    `env:"POLL_INTERVAL"`
-	ReportInterval int    `env:"REPORT_INTERVAL"`
-	RateLimit      int    `env:"RATE_LIMIT"`
-	PprofFlag      bool   `env:"PPROF_FLAG"`
+	ServerAddress  string `env:"ADDRESS"         json:"server_address,omitempty"`
+	SigningKey     string `env:"KEY"             json:"signing_key,omitempty"`
+	CryptoKey      string `env:"CRYPTO_KEY"      json:"crypto_key,omitempty"`
+	ConfigPath     string `env:"CONFIG"          json:"config_path,omitempty"`
+	PollInterval   int    `env:"POLL_INTERVAL"   json:"poll_interval,omitempty"`
+	ReportInterval int    `env:"REPORT_INTERVAL" json:"report_interval,omitempty"`
+	RateLimit      int    `env:"RATE_LIMIT"      json:"rate_limit,omitempty"`
+	PprofFlag      bool   `env:"PPROF_FLAG"      json:"pprof_flag,omitempty"`
 }
 
 // ParseConfig initializes a new Config instance with default values, then overrides these values
@@ -53,6 +57,7 @@ func ParseConfig() (*Config, error) {
 		RateLimit:      defaultRateLimit,
 		PprofFlag:      defaultPprofFlag,
 		CryptoKey:      defaultCryptoKey,
+		ConfigPath:     defaultConfigPath,
 	}
 
 	// Parse command-line arguments or set default settings if no arguments are provided.
@@ -63,7 +68,52 @@ func ParseConfig() (*Config, error) {
 		return nil, fmt.Errorf("failed to parse environment variables: %w", err)
 	}
 
+	if cfg.ConfigPath != defaultConfigPath {
+		if err := mergeConfigFile(&cfg); err != nil {
+			return nil, fmt.Errorf("failed to merge configuration file: %w", err)
+		}
+	}
+
 	return &cfg, nil
+}
+
+func mergeConfigFile(cfg *Config) error {
+	data, err := os.ReadFile(cfg.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	tempCfg := Config{}
+	if err := json.Unmarshal(data, &tempCfg); err != nil {
+		return fmt.Errorf("cannot parse JSON config %q: %w", cfg.ConfigPath, err)
+	}
+
+	// [ДЛЯ РЕВЬЮ] Если честно, то мне очень не нравится такая реализация и она точно будет работать неправильно,
+	// если пользователь самостоятельно укажет в переменных окружения или флагах параметры, совпадающие с дефолтными,
+	// Но я не смог придумать что-то лучше, чтобы при этом не нужно было полностью переписывать всю остальную логику.
+	if cfg.ServerAddress == defaultServerAddress && tempCfg.ServerAddress != defaultServerAddress {
+		cfg.ServerAddress = tempCfg.ServerAddress
+	}
+	if cfg.SigningKey == defaultSigningKey && tempCfg.SigningKey != defaultSigningKey {
+		cfg.SigningKey = tempCfg.SigningKey
+	}
+	if cfg.CryptoKey == defaultCryptoKey && tempCfg.CryptoKey != defaultCryptoKey {
+		cfg.CryptoKey = tempCfg.CryptoKey
+	}
+	if cfg.PollInterval == defaultPollInterval && tempCfg.PollInterval != defaultPollInterval {
+		cfg.PollInterval = tempCfg.PollInterval
+	}
+	if cfg.ReportInterval == defaultReportInterval && tempCfg.ReportInterval != defaultReportInterval {
+		cfg.ReportInterval = tempCfg.ReportInterval
+	}
+	if cfg.RateLimit == defaultRateLimit && tempCfg.RateLimit != defaultRateLimit {
+		cfg.RateLimit = tempCfg.RateLimit
+	}
+	if !cfg.PprofFlag && tempCfg.PprofFlag {
+		cfg.PprofFlag = tempCfg.PprofFlag
+	}
+
+	return nil
 }
 
 // parseFlagsOrSetDefault populates the Config structure with values provided as command-line flags.
@@ -80,5 +130,6 @@ func parseFlagsOrSetDefault(cfg *Config) {
 	flag.IntVar(&cfg.RateLimit, "l", cfg.RateLimit, "Maximum rate for sending HTTP requests per interval.")
 	flag.BoolVar(&cfg.PprofFlag, "pf", cfg.PprofFlag, "Enable or disable profiling with pprof.")
 	flag.StringVar(&cfg.CryptoKey, "crypto-key", cfg.CryptoKey, "Path to public key file.")
+	flag.StringVar(&cfg.ConfigPath, "c", cfg.ConfigPath, "Path to config file.")
 	flag.Parse()
 }

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -28,6 +28,7 @@ func TestParseConfig(t *testing.T) {
 				SigningKey:     defaultSigningKey,
 				RateLimit:      defaultRateLimit,
 				PprofFlag:      defaultPprofFlag,
+				CryptoKey:      defaultCryptoKey,
 			},
 			expectError: false,
 		},
@@ -40,6 +41,7 @@ func TestParseConfig(t *testing.T) {
 				"KEY":             "testpass",
 				"RATE_LIMIT":      "8",
 				"PPROF_FLAG":      "true",
+				"CRYPTO_KEY":      "env_example/path",
 			},
 			args: []string{},
 			expected: Config{
@@ -49,6 +51,7 @@ func TestParseConfig(t *testing.T) {
 				SigningKey:     "testpass",
 				RateLimit:      8,
 				PprofFlag:      true,
+				CryptoKey:      "env_example/path",
 			},
 			expectError: false,
 		},
@@ -62,6 +65,7 @@ func TestParseConfig(t *testing.T) {
 				"-k", "testpass",
 				"-l", "8",
 				"-pf",
+				"-crypto-key", "cmd_example/path",
 			},
 			expected: Config{
 				ServerAddress:  "flagserver:8000",
@@ -70,6 +74,7 @@ func TestParseConfig(t *testing.T) {
 				SigningKey:     "testpass",
 				RateLimit:      8,
 				PprofFlag:      true,
+				CryptoKey:      "cmd_example/path",
 			},
 			expectError: false,
 		},
@@ -82,6 +87,7 @@ func TestParseConfig(t *testing.T) {
 				"KEY":             "testpass",
 				"RATE_LIMIT":      "8",
 				"PPROF_FLAG":      "true",
+				"CRYPTO_KEY":      "env_example/path",
 			},
 			args: []string{
 				"-a", "flagserver:8000",
@@ -89,6 +95,7 @@ func TestParseConfig(t *testing.T) {
 				"-r", "12",
 				"-k", "testpasscmd",
 				"-l", "8",
+				"-crypto-key", "cmd_example/path",
 			},
 			expected: Config{
 				ServerAddress:  "envserver:9000",
@@ -97,6 +104,7 @@ func TestParseConfig(t *testing.T) {
 				SigningKey:     "testpass",
 				RateLimit:      8,
 				PprofFlag:      true,
+				CryptoKey:      "env_example/path",
 			},
 			expectError: false,
 		},

--- a/internal/agent/send/request_builder.go
+++ b/internal/agent/send/request_builder.go
@@ -157,7 +157,7 @@ func encryptWithPublicKeyHybrid(
 
 	const aesKeySize = 32
 	aesKey := make([]byte, aesKeySize)
-	if _, err := rand.Read(aesKey); err != nil {
+	if _, err = rand.Read(aesKey); err != nil {
 		return nil, nil, fmt.Errorf("failed to generate AES key: %w", err)
 	}
 
@@ -172,7 +172,7 @@ func encryptWithPublicKeyHybrid(
 	}
 
 	nonce := make([]byte, aesGCM.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
 		return nil, nil, fmt.Errorf("failed to generate nonce: %w", err)
 	}
 

--- a/internal/agent/send/request_builder.go
+++ b/internal/agent/send/request_builder.go
@@ -1,8 +1,15 @@
 package send
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
+	"io"
 
 	"github.com/gdyunin/metricol.git/internal/agent/send/compress"
 	"github.com/gdyunin/metricol.git/pkg/sign"
@@ -47,7 +54,7 @@ func (b *RequestBuilder) Build(method string, endpoint string, body []byte) *res
 	return req
 }
 
-// BuildWithGzip creates an HTTP request with a gzip-compressed body.
+// BuildWithParams creates an HTTP request with a gzip-compressed body.
 // It compresses the provided body data and, if a signing key is provided,
 // computes and encodes a signature that is added as a header.
 //
@@ -60,13 +67,28 @@ func (b *RequestBuilder) Build(method string, endpoint string, body []byte) *res
 // Returns:
 //   - *resty.Request: The constructed HTTP request with a gzip-compressed body.
 //   - error: An error if the compression process fails.
-func (b *RequestBuilder) BuildWithGzip(method string, endpoint string, body []byte, signingKey string) (
+func (b *RequestBuilder) BuildWithParams(method string, endpoint string, body []byte, signingKey string, publicKeyPEM string) (
 	*resty.Request,
 	error,
 ) {
 	var s string
 	if signingKey != "" {
 		s = base64.StdEncoding.EncodeToString(sign.MakeSign(body, signingKey))
+	}
+
+	// Encrypt the body using the provided public key.
+	// Using hybrid crypto method for correct work with large body.
+	// [ДЛЯ РЕВЬЮ] Использую тут гибридное шифрование, т.к. тело большое и не шифруется "маленькими" (4096) rsa.
+	// Поэтому в качестве выхода из ситуации подобрал такой подход. Будет работать даже если мы откажемся от сжатия.
+	var e string
+	if publicKeyPEM != "" {
+		encryptedBody, encryptedKey, err := encryptWithPublicKeyHybrid(body, publicKeyPEM)
+		if err != nil {
+			return nil, fmt.Errorf("encryption failed for request body: %w", err)
+		}
+
+		body = encryptedBody
+		e = base64.StdEncoding.EncodeToString(encryptedKey)
 	}
 
 	body, err := b.compressor.Compress(body)
@@ -76,9 +98,79 @@ func (b *RequestBuilder) BuildWithGzip(method string, endpoint string, body []by
 
 	req := b.Build(method, endpoint, body)
 	req.SetHeader("Content-Encoding", "gzip")
+
 	if s != "" {
 		req.SetHeader("HashSHA256", s)
 	}
+	if e != "" {
+		req.SetHeader("X-Encrypted-Key", e)
+	}
 
 	return req, nil
+}
+
+// encryptWithPublicKeyHybrid encrypts the given data using a hybrid encryption scheme
+// that combines AES-GCM for data encryption and RSA for encrypting the AES key.
+//
+// Parameters:
+//   - data: The plaintext data to be encrypted.
+//   - publicKeyPEM: The RSA public key in PEM format used to encrypt the AES key.
+//
+// Returns:
+//   - encryptedData: The encrypted data, including the AES-GCM nonce and ciphertext.
+//   - encryptedKey: The AES key encrypted with the RSA public key.
+//   - err: An error if any step of the encryption process fails.
+//
+// The function performs the following steps:
+//  1. Parses the provided RSA public key in PEM format.
+//  2. Generates a random 256-bit AES key.
+//  3. Encrypts the data using AES-GCM with the generated AES key.
+//  4. Encrypts the AES key using the RSA public key.
+//
+// Errors are returned if the public key is invalid, the AES key generation fails,
+// or any encryption step encounters an issue.
+func encryptWithPublicKeyHybrid(data []byte, publicKeyPEM string) (encryptedData []byte, encryptedKey []byte, err error) {
+	block, _ := pem.Decode([]byte(publicKeyPEM))
+	if block == nil || block.Type != "PUBLIC KEY" {
+		return nil, nil, fmt.Errorf("invalid public key PEM format")
+	}
+
+	pubKeyInterface, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	rsaPubKey, ok := pubKeyInterface.(*rsa.PublicKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("provided key is not an RSA public key")
+	}
+
+	aesKey := make([]byte, 32)
+	if _, err := rand.Read(aesKey); err != nil {
+		return nil, nil, fmt.Errorf("failed to generate AES key: %w", err)
+	}
+
+	blockCipher, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(blockCipher)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create AES-GCM: %w", err)
+	}
+
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, fmt.Errorf("failed to generate nonce: %w", err)
+	}
+
+	ciphertext := aesGCM.Seal(nonce, nonce, data, nil)
+
+	encryptedAESKey, err := rsa.EncryptPKCS1v15(rand.Reader, rsaPubKey, aesKey)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to encrypt AES key with RSA: %w", err)
+	}
+
+	return ciphertext, encryptedAESKey, nil
 }

--- a/internal/agent/send/request_builder_test.go
+++ b/internal/agent/send/request_builder_test.go
@@ -74,7 +74,7 @@ func TestBuildWithGzip(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			req, err := builder.BuildWithGzip(tt.method, tt.endpoint, tt.body, tt.signingKey)
+			req, err := builder.BuildWithParams(tt.method, tt.endpoint, tt.body, tt.signingKey, "")
 			if tt.expectErr {
 				assert.Error(t, err)
 			} else {

--- a/internal/agent/send/stream_sender_test.go
+++ b/internal/agent/send/stream_sender_test.go
@@ -105,7 +105,7 @@ func TestStreamSender_SendBatch(t *testing.T) {
 			logger := zap.NewNop().Sugar()
 
 			// Initialize the StreamSender.
-			sender := NewStreamSender(dummyChan, time.Second, 1, ts.URL, "dummySigningKey", logger)
+			sender := NewStreamSender(dummyChan, time.Second, 1, ts.URL, "dummySigningKey", "", logger)
 			// Override the requestBuilder with our instance that uses the original compressor.
 			sender.requestBuilder = builder
 

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -18,6 +18,7 @@ const (
 	defaultDatabaseDSN     = ""
 	defaultSigningKey      = ""
 	defaultPprofFlag       = false
+	defaultCryptoKey       = ""
 )
 
 // Config holds the configuration for the server, including its address,
@@ -32,6 +33,7 @@ type Config struct {
 	StoreInterval   int    `env:"STORE_INTERVAL"`    // StoreInterval is the interval (in seconds) for storing data.
 	Restore         bool   `env:"RESTORE"`           // Restore indicates whether to restore previous state on startup.
 	PprofFlag       bool   `env:"PPROF_SERVER_FLAG"` // PprofFlag toggles the use of pprof profiling.
+	CryptoKey       string `env:"CRYPTO_KEY"`        // Path to private key file.
 }
 
 // ParseConfig initializes the Config with default values, overrides them with command-line flags if provided,
@@ -51,6 +53,7 @@ func ParseConfig() (*Config, error) {
 		DatabaseDSN:     defaultDatabaseDSN,
 		SigningKey:      defaultSigningKey,
 		PprofFlag:       defaultPprofFlag,
+		CryptoKey:      defaultCryptoKey,
 	}
 
 	// Populate the configuration from command-line flags.
@@ -80,5 +83,6 @@ func parseFlagsOrSetDefault(cfg *Config) {
 	flag.StringVar(&cfg.DatabaseDSN, "d", cfg.DatabaseDSN, "Database DSN")
 	flag.StringVar(&cfg.SigningKey, "k", cfg.SigningKey, "Signing key for checking request signatures.")
 	flag.BoolVar(&cfg.PprofFlag, "pf", cfg.PprofFlag, "Enable or disable profiling with pprof")
+	flag.StringVar(&cfg.CryptoKey, "crypto-key", cfg.CryptoKey, "Path to private key file.")
 	flag.Parse()
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -3,10 +3,8 @@
 package config
 
 import (
-	"encoding/json"
 	"flag"
 	"fmt"
-	"os"
 
 	"github.com/caarlos0/env/v6"
 )
@@ -28,14 +26,14 @@ const (
 // The configuration values can be provided via environment variables, command-line flags,
 // or default settings defined in the package.
 type Config struct {
-	ServerAddress   string `env:"ADDRESS"           json:"server_address"`
-	FileStoragePath string `env:"FILE_STORAGE_PATH" json:"file_storage_path"`
-	DatabaseDSN     string `env:"DATABASE_DSN"      json:"database_dsn"`
-	SigningKey      string `env:"KEY"               json:"signing_key"`
-	CryptoKey       string `env:"CRYPTO_KEY"        json:"crypto_key"`
-	StoreInterval   int    `env:"STORE_INTERVAL"    json:"store_interval"`
-	Restore         bool   `env:"RESTORE"           json:"restore"`
-	PprofFlag       bool   `env:"PPROF_SERVER_FLAG" json:"pprof_flag"`
+	ServerAddress   string `env:"ADDRESS"`
+	FileStoragePath string `env:"FILE_STORAGE_PATH"`
+	DatabaseDSN     string `env:"DATABASE_DSN"`
+	SigningKey      string `env:"KEY"`
+	CryptoKey       string `env:"CRYPTO_KEY"`
+	StoreInterval   int    `env:"STORE_INTERVAL"`
+	Restore         bool   `env:"RESTORE"`
+	PprofFlag       bool   `env:"PPROF_SERVER_FLAG"`
 }
 
 // ParseConfig initializes the Config with default values, overrides them with command-line flags if provided,
@@ -45,35 +43,6 @@ type Config struct {
 // Returns:
 //   - *Config: A pointer to the populated Config structure.
 //   - error: An error if parsing of environment variables fails.
-//
-// ParseConfig initializes and returns a Config struct by parsing configuration
-// values from multiple sources in the following order of precedence:
-// 1. Default settings defined in the code.
-// 2. Configuration file, if available.
-// 3. Command-line flags, which override the previous values.
-// 4. Environment variables, which override all previous values.
-//
-// If any error occurs during parsing the configuration file or environment
-// variables, it returns an error.
-//
-// Returns:
-//   - A pointer to the populated Config struct.
-//   - An error if parsing fails at any stage.
-//
-// ParseConfig initializes and returns a Config object by combining default values,
-// configuration file settings, command-line flags, and environment variables.
-//
-// The function performs the following steps:
-//  1. Initializes a Config object with default values.
-//  2. Attempts to parse a configuration file to override default values.
-//     If parsing the file fails, an error is returned.
-//  3. Parses command-line flags to override existing configuration values or set defaults.
-//  4. Parses environment variables to override configuration values if they are set.
-//     If parsing environment variables fails, an error is returned.
-//
-// Returns:
-// - A pointer to the populated Config object.
-// - An error if any step in the configuration process fails.
 func ParseConfig() (*Config, error) {
 	// Default settings for the server configuration.
 	cfg := Config{
@@ -87,10 +56,6 @@ func ParseConfig() (*Config, error) {
 		CryptoKey:       defaultCryptoKey,
 	}
 
-	if err := parseConfigFile(&cfg); err != nil {
-		return nil, fmt.Errorf("error parsing config file: %w", err)
-	}
-
 	// Populate the configuration from command-line flags.
 	parseFlagsOrSetDefault(&cfg)
 
@@ -100,45 +65,6 @@ func ParseConfig() (*Config, error) {
 	}
 
 	return &cfg, nil
-}
-
-// parseConfigFile parses the configuration for the application.
-// It first attempts to read the configuration file path from the command-line
-// flag "-c". If the flag is not provided, it falls back to the "CONFIG"
-// environment variable. If a configuration file path is found, it reads the
-// file and unmarshals its JSON content into the provided Config struct.
-//
-// Parameters:
-//   - cfg: A pointer to a Config struct where the parsed configuration will be stored.
-//
-// Returns:
-//   - An error if there is an issue with parsing command-line flags, reading the
-//     configuration file, or unmarshaling the JSON content. Returns nil if the
-//     configuration is successfully parsed.
-func parseConfigFile(cfg *Config) error {
-	var configPath string
-
-	fs := flag.NewFlagSet("config", flag.ContinueOnError)
-	fs.StringVar(&configPath, "c", "", "Path to JSON config file")
-	if err := fs.Parse(os.Args[1:]); err != nil {
-		return fmt.Errorf("error parsing command-line flags: %w", err)
-	}
-
-	if configPath == "" {
-		configPath = os.Getenv("CONFIG")
-	}
-
-	if configPath != "" {
-		data, err := os.ReadFile(configPath)
-		if err != nil {
-			return fmt.Errorf("failed to read config file: %w", err)
-		}
-
-		if err := json.Unmarshal(data, cfg); err != nil {
-			return fmt.Errorf("cannot parse JSON config %q: %w", configPath, err)
-		}
-	}
-	return nil
 }
 
 // parseFlagsOrSetDefault populates the Config from command-line flags,

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -3,8 +3,10 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/caarlos0/env/v6"
 )
@@ -19,6 +21,7 @@ const (
 	defaultSigningKey      = ""
 	defaultPprofFlag       = false
 	defaultCryptoKey       = ""
+	defaultConfigPath      = ""
 )
 
 // Config holds the configuration for the server, including its address,
@@ -26,14 +29,15 @@ const (
 // The configuration values can be provided via environment variables, command-line flags,
 // or default settings defined in the package.
 type Config struct {
-	ServerAddress   string `env:"ADDRESS"`
-	FileStoragePath string `env:"FILE_STORAGE_PATH"`
-	DatabaseDSN     string `env:"DATABASE_DSN"`
-	SigningKey      string `env:"KEY"`
-	CryptoKey       string `env:"CRYPTO_KEY"`
-	StoreInterval   int    `env:"STORE_INTERVAL"`
-	Restore         bool   `env:"RESTORE"`
-	PprofFlag       bool   `env:"PPROF_SERVER_FLAG"`
+	ServerAddress   string `env:"ADDRESS"           json:"server_address,omitempty"`
+	FileStoragePath string `env:"FILE_STORAGE_PATH" json:"file_storage_path,omitempty"`
+	DatabaseDSN     string `env:"DATABASE_DSN"      json:"database_dsn,omitempty"`
+	SigningKey      string `env:"KEY"               json:"signing_key,omitempty"`
+	CryptoKey       string `env:"CRYPTO_KEY"        json:"crypto_key,omitempty"`
+	ConfigPath      string `env:"CONFIG"            json:"config_path,omitempty"`
+	StoreInterval   int    `env:"STORE_INTERVAL"    json:"store_interval,omitempty"`
+	Restore         bool   `env:"RESTORE"           json:"restore,omitempty"`
+	PprofFlag       bool   `env:"PPROF_SERVER_FLAG" json:"pprof_flag,omitempty"`
 }
 
 // ParseConfig initializes the Config with default values, overrides them with command-line flags if provided,
@@ -54,6 +58,7 @@ func ParseConfig() (*Config, error) {
 		SigningKey:      defaultSigningKey,
 		PprofFlag:       defaultPprofFlag,
 		CryptoKey:       defaultCryptoKey,
+		ConfigPath:      defaultConfigPath,
 	}
 
 	// Populate the configuration from command-line flags.
@@ -64,7 +69,56 @@ func ParseConfig() (*Config, error) {
 		return nil, fmt.Errorf("error parse env variables %w", err)
 	}
 
+	if cfg.ConfigPath != defaultConfigPath {
+		if err := mergeConfigFile(&cfg); err != nil {
+			return nil, fmt.Errorf("failed to merge configuration file: %w", err)
+		}
+	}
+
 	return &cfg, nil
+}
+
+func mergeConfigFile(cfg *Config) error {
+	data, err := os.ReadFile(cfg.ConfigPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	tempCfg := Config{}
+	if err := json.Unmarshal(data, &tempCfg); err != nil {
+		return fmt.Errorf("cannot parse JSON config %q: %w", cfg.ConfigPath, err)
+	}
+
+	// [ДЛЯ РЕВЬЮ] Если честно, то мне очень не нравится такая реализация и она точно будет работать неправильно,
+	// если пользователь самостоятельно укажет в переменных окружения или флагах параметры, совпадающие с дефолтными,
+	// Но я не смог придумать что-то лучше, чтобы при этом не нужно было полностью переписывать всю остальную логику.
+
+	if cfg.ServerAddress == defaultServerAddress && tempCfg.ServerAddress != defaultServerAddress {
+		cfg.ServerAddress = tempCfg.ServerAddress
+	}
+	if cfg.FileStoragePath == defaultFileStoragePath && tempCfg.FileStoragePath != defaultFileStoragePath {
+		cfg.FileStoragePath = tempCfg.FileStoragePath
+	}
+	if cfg.DatabaseDSN == defaultDatabaseDSN && tempCfg.DatabaseDSN != defaultDatabaseDSN {
+		cfg.DatabaseDSN = tempCfg.DatabaseDSN
+	}
+	if cfg.SigningKey == defaultSigningKey && tempCfg.SigningKey != defaultSigningKey {
+		cfg.SigningKey = tempCfg.SigningKey
+	}
+	if cfg.CryptoKey == defaultCryptoKey && tempCfg.CryptoKey != defaultCryptoKey {
+		cfg.CryptoKey = tempCfg.CryptoKey
+	}
+	if cfg.StoreInterval == defaultStoreInterval && tempCfg.StoreInterval != defaultStoreInterval {
+		cfg.StoreInterval = tempCfg.StoreInterval
+	}
+	if cfg.Restore && !tempCfg.Restore {
+		cfg.Restore = tempCfg.Restore
+	}
+	if !cfg.PprofFlag && tempCfg.PprofFlag {
+		cfg.PprofFlag = tempCfg.PprofFlag
+	}
+
+	return nil
 }
 
 // parseFlagsOrSetDefault populates the Config from command-line flags,
@@ -84,5 +138,6 @@ func parseFlagsOrSetDefault(cfg *Config) {
 	flag.StringVar(&cfg.SigningKey, "k", cfg.SigningKey, "Signing key for checking request signatures.")
 	flag.BoolVar(&cfg.PprofFlag, "pf", cfg.PprofFlag, "Enable or disable profiling with pprof")
 	flag.StringVar(&cfg.CryptoKey, "crypto-key", cfg.CryptoKey, "Path to private key file.")
+	flag.StringVar(&cfg.ConfigPath, "c", cfg.ConfigPath, "Path to config file.")
 	flag.Parse()
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -3,8 +3,10 @@
 package config
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/caarlos0/env/v6"
 )
@@ -26,14 +28,14 @@ const (
 // The configuration values can be provided via environment variables, command-line flags,
 // or default settings defined in the package.
 type Config struct {
-	ServerAddress   string `env:"ADDRESS"`
-	FileStoragePath string `env:"FILE_STORAGE_PATH"`
-	DatabaseDSN     string `env:"DATABASE_DSN"`
-	SigningKey      string `env:"KEY"`
-	CryptoKey       string `env:"CRYPTO_KEY"`
-	StoreInterval   int    `env:"STORE_INTERVAL"`
-	Restore         bool   `env:"RESTORE"`
-	PprofFlag       bool   `env:"PPROF_SERVER_FLAG"`
+	ServerAddress   string `env:"ADDRESS"           json:"server_address"`
+	FileStoragePath string `env:"FILE_STORAGE_PATH" json:"file_storage_path"`
+	DatabaseDSN     string `env:"DATABASE_DSN"      json:"database_dsn"`
+	SigningKey      string `env:"KEY"               json:"signing_key"`
+	CryptoKey       string `env:"CRYPTO_KEY"        json:"crypto_key"`
+	StoreInterval   int    `env:"STORE_INTERVAL"    json:"store_interval"`
+	Restore         bool   `env:"RESTORE"           json:"restore"`
+	PprofFlag       bool   `env:"PPROF_SERVER_FLAG" json:"pprof_flag"`
 }
 
 // ParseConfig initializes the Config with default values, overrides them with command-line flags if provided,
@@ -43,6 +45,35 @@ type Config struct {
 // Returns:
 //   - *Config: A pointer to the populated Config structure.
 //   - error: An error if parsing of environment variables fails.
+//
+// ParseConfig initializes and returns a Config struct by parsing configuration
+// values from multiple sources in the following order of precedence:
+// 1. Default settings defined in the code.
+// 2. Configuration file, if available.
+// 3. Command-line flags, which override the previous values.
+// 4. Environment variables, which override all previous values.
+//
+// If any error occurs during parsing the configuration file or environment
+// variables, it returns an error.
+//
+// Returns:
+//   - A pointer to the populated Config struct.
+//   - An error if parsing fails at any stage.
+//
+// ParseConfig initializes and returns a Config object by combining default values,
+// configuration file settings, command-line flags, and environment variables.
+//
+// The function performs the following steps:
+//  1. Initializes a Config object with default values.
+//  2. Attempts to parse a configuration file to override default values.
+//     If parsing the file fails, an error is returned.
+//  3. Parses command-line flags to override existing configuration values or set defaults.
+//  4. Parses environment variables to override configuration values if they are set.
+//     If parsing environment variables fails, an error is returned.
+//
+// Returns:
+// - A pointer to the populated Config object.
+// - An error if any step in the configuration process fails.
 func ParseConfig() (*Config, error) {
 	// Default settings for the server configuration.
 	cfg := Config{
@@ -56,6 +87,10 @@ func ParseConfig() (*Config, error) {
 		CryptoKey:       defaultCryptoKey,
 	}
 
+	if err := parseConfigFile(&cfg); err != nil {
+		return nil, fmt.Errorf("error parsing config file: %w", err)
+	}
+
 	// Populate the configuration from command-line flags.
 	parseFlagsOrSetDefault(&cfg)
 
@@ -65,6 +100,45 @@ func ParseConfig() (*Config, error) {
 	}
 
 	return &cfg, nil
+}
+
+// parseConfigFile parses the configuration for the application.
+// It first attempts to read the configuration file path from the command-line
+// flag "-c". If the flag is not provided, it falls back to the "CONFIG"
+// environment variable. If a configuration file path is found, it reads the
+// file and unmarshals its JSON content into the provided Config struct.
+//
+// Parameters:
+//   - cfg: A pointer to a Config struct where the parsed configuration will be stored.
+//
+// Returns:
+//   - An error if there is an issue with parsing command-line flags, reading the
+//     configuration file, or unmarshaling the JSON content. Returns nil if the
+//     configuration is successfully parsed.
+func parseConfigFile(cfg *Config) error {
+	var configPath string
+
+	fs := flag.NewFlagSet("config", flag.ContinueOnError)
+	fs.StringVar(&configPath, "c", "", "Path to JSON config file")
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		return fmt.Errorf("error parsing command-line flags: %w", err)
+	}
+
+	if configPath == "" {
+		configPath = os.Getenv("CONFIG")
+	}
+
+	if configPath != "" {
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			return fmt.Errorf("failed to read config file: %w", err)
+		}
+
+		if err := json.Unmarshal(data, cfg); err != nil {
+			return fmt.Errorf("cannot parse JSON config %q: %w", configPath, err)
+		}
+	}
+	return nil
 }
 
 // parseFlagsOrSetDefault populates the Config from command-line flags,

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -26,14 +26,14 @@ const (
 // The configuration values can be provided via environment variables, command-line flags,
 // or default settings defined in the package.
 type Config struct {
-	ServerAddress   string `env:"ADDRESS"`           // ServerAddress is the address on which the server listens.
-	FileStoragePath string `env:"FILE_STORAGE_PATH"` // FileStoragePath is the file system path for storage.
-	DatabaseDSN     string `env:"DATABASE_DSN"`      // DatabaseDSN is the Data Source Name for the database connection.
-	SigningKey      string `env:"KEY"`               // SigningKey is used for checking request signatures.
-	StoreInterval   int    `env:"STORE_INTERVAL"`    // StoreInterval is the interval (in seconds) for storing data.
-	Restore         bool   `env:"RESTORE"`           // Restore indicates whether to restore previous state on startup.
-	PprofFlag       bool   `env:"PPROF_SERVER_FLAG"` // PprofFlag toggles the use of pprof profiling.
-	CryptoKey       string `env:"CRYPTO_KEY"`        // Path to private key file.
+	ServerAddress   string `env:"ADDRESS"`
+	FileStoragePath string `env:"FILE_STORAGE_PATH"`
+	DatabaseDSN     string `env:"DATABASE_DSN"`
+	SigningKey      string `env:"KEY"`
+	CryptoKey       string `env:"CRYPTO_KEY"`
+	StoreInterval   int    `env:"STORE_INTERVAL"`
+	Restore         bool   `env:"RESTORE"`
+	PprofFlag       bool   `env:"PPROF_SERVER_FLAG"`
 }
 
 // ParseConfig initializes the Config with default values, overrides them with command-line flags if provided,
@@ -53,7 +53,7 @@ func ParseConfig() (*Config, error) {
 		DatabaseDSN:     defaultDatabaseDSN,
 		SigningKey:      defaultSigningKey,
 		PprofFlag:       defaultPprofFlag,
-		CryptoKey:      defaultCryptoKey,
+		CryptoKey:       defaultCryptoKey,
 	}
 
 	// Populate the configuration from command-line flags.

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -29,6 +29,7 @@ func TestParseConfig(t *testing.T) {
 				StoreInterval:   defaultStoreInterval,
 				Restore:         defaultRestoreFlag,
 				PprofFlag:       defaultPprofFlag,
+				CryptoKey:       defaultCryptoKey,
 			},
 			expectError: false,
 		},
@@ -42,6 +43,7 @@ func TestParseConfig(t *testing.T) {
 				"STORE_INTERVAL":    "300",
 				"RESTORE":           "true",
 				"PPROF_SERVER_FLAG": "true",
+				"CRYPTO_KEY":        "env_example/path",
 			},
 			args: []string{},
 			expected: Config{
@@ -52,6 +54,7 @@ func TestParseConfig(t *testing.T) {
 				StoreInterval:   300,
 				Restore:         true,
 				PprofFlag:       true,
+				CryptoKey:       "env_example/path",
 			},
 			expectError: false,
 		},
@@ -65,6 +68,7 @@ func TestParseConfig(t *testing.T) {
 				"-k", "flagkey",
 				"-i", "500",
 				"-r", "-pf",
+				"-crypto-key", "cmd_example/path",
 			},
 			expected: Config{
 				ServerAddress:   "flagserver:8000",
@@ -74,6 +78,7 @@ func TestParseConfig(t *testing.T) {
 				StoreInterval:   500,
 				Restore:         true,
 				PprofFlag:       true,
+				CryptoKey:       "cmd_example/path",
 			},
 			expectError: false,
 		},
@@ -87,6 +92,7 @@ func TestParseConfig(t *testing.T) {
 				"STORE_INTERVAL":    "300",
 				"RESTORE":           "true",
 				"PPROF_SERVER_FLAG": "true",
+				"CRYPTO_KEY":        "env_example/path",
 			},
 			args: []string{
 				"-a", "flagserver:8000",
@@ -96,6 +102,7 @@ func TestParseConfig(t *testing.T) {
 				"-i", "500",
 				"-r", "true",
 				"-pf", "false",
+				"-crypto-key", "cmd_example/path",
 			},
 			expected: Config{
 				ServerAddress:   "envserver:9000",
@@ -105,6 +112,7 @@ func TestParseConfig(t *testing.T) {
 				StoreInterval:   300,
 				Restore:         true,
 				PprofFlag:       true,
+				CryptoKey:       "env_example/path",
 			},
 			expectError: false,
 		},

--- a/internal/server/delivery/http_server.go
+++ b/internal/server/delivery/http_server.go
@@ -42,6 +42,7 @@ type EchoServer struct {
 	addr        string                    // addr is the server address to listen on.
 	tmplPath    string                    // tmplPath is the directory path to the HTML templates.
 	signingKey  string                    // signingKey is used for request signing and authentication.
+	cryptoKey   string
 }
 
 // NewEchoServer creates and configures a new EchoServer instance.
@@ -59,6 +60,7 @@ type EchoServer struct {
 func NewEchoServer(
 	serverAddress string,
 	signingKey string,
+	cryptoKey string,
 	repo repository.Repository,
 	logger *zap.SugaredLogger,
 ) *EchoServer {
@@ -67,6 +69,7 @@ func NewEchoServer(
 		logger:      logger,
 		addr:        serverAddress,
 		signingKey:  signingKey,
+		cryptoKey:   cryptoKey,
 		tmplPath:    defaultTemplatesPath,
 		metricsCtrl: controller.NewMetricService(repo),
 	}
@@ -160,6 +163,7 @@ func (s *EchoServer) setupGeneralMiddlewares() {
 		echoMiddleware.Decompress(),
 		custMiddleware.Auth(s.signingKey),
 		custMiddleware.Sign(s.signingKey),
+		custMiddleware.Crypto(s.cryptoKey, requestLogger.Named("crypto")),
 		custMiddleware.Gzip(requestLogger.Named("gzip_writer")),
 	)
 }

--- a/internal/server/delivery/middleware/crypto.go
+++ b/internal/server/delivery/middleware/crypto.go
@@ -1,0 +1,97 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"go.uber.org/zap"
+)
+
+// [ДЛЯ РЕВЬЮ] Этот волшебный 🩼 -- плата за экономию на переделывании `internal/server/delivery/http_server.go`...
+var cryptoIgnoredPath = map[string]bool{
+	"/":     true,
+	"/ping": true,
+}
+
+func Crypto(cryptoKey string, logger *zap.SugaredLogger) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) (err error) {
+			if cryptoKey == "" || cryptoIgnoredPath[c.Request().URL.Path] {
+				return next(c)
+			}
+
+			encryptedKeyB64 := c.Request().Header.Get("X-Encrypted-Key")
+			encryptedKey, err := base64.StdEncoding.DecodeString(encryptedKeyB64)
+			if err != nil {
+				logger.Errorf("failed to decode base64 encrypted key: %v", err)
+				return c.String(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+			}
+
+			encryptedBody, err := io.ReadAll(c.Request().Body)
+			if err != nil {
+				logger.Errorf("failed to read request body: %v", err)
+				return c.String(http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
+			}
+
+			decryptedBody, err := decryptWithPrivateKeyHybrid(encryptedBody, encryptedKey, cryptoKey)
+			if err != nil {
+				return c.String(http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+			}
+
+			c.Request().Body = io.NopCloser(bytes.NewReader(decryptedBody))
+
+			return next(c)
+		}
+	}
+}
+
+func decryptWithPrivateKeyHybrid(encryptedData []byte, encryptedKey []byte, privateKeyPEM string) ([]byte, error) {
+	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil || block.Type != "RSA PRIVATE KEY" {
+		return nil, fmt.Errorf("invalid private key PEM format")
+	}
+
+	privKey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	aesKey, err := rsa.DecryptPKCS1v15(rand.Reader, privKey, encryptedKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt AES key: %w", err)
+	}
+
+	blockCipher, err := aes.NewCipher(aesKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(blockCipher)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AES-GCM: %w", err)
+	}
+
+	if len(encryptedData) < aesGCM.NonceSize() {
+		return nil, fmt.Errorf("encrypted data too short")
+	}
+
+	nonce := encryptedData[:aesGCM.NonceSize()]
+	ciphertext := encryptedData[aesGCM.NonceSize():]
+
+	plaintext, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt data: %w", err)
+	}
+
+	return plaintext, nil
+}


### PR DESCRIPTION
Для генерации ключей (PEM) сделал небольшую утилиту, подробнее в `/cmd/keycli/readme.md`, а сами *.pem добавил в `.gitignore`, чтобы не таскать их в репо, т.к. не секьюрно, хоть и учебный проект :)

Чтение json из файла в конфигах мне не очень нравится, как я смог реализовать, но это компромиссный вариант, чтобы не переписывать вообще всю логику чтения конфигурации. В общем не супер чисто, но эффективно.

Graceful shutdown я не трогал, потому что вроде уже существующее поведение удовлетворяет требованиям ТЗ. Единственное, что добавил сигналы, которых не хватало.